### PR TITLE
Small optimisations of `rd_to_date`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,8 +313,8 @@ pub const fn rd_to_date(n: i32) -> (i32, u32, u32) {
     let n = n.wrapping_add(DAY_OFFSET) as u32;
     let n = 4 * n + 3;
     let c = n / 146097;
-    let n = n % 146097 / 4;
-    let n = 4 * n + 3;
+    let r = n % 146097;
+    let n = r | 3;
     let p = 2939745 * n as u64;
     let z = (p / 2u64.pow(32)) as u32;
     let n = (p % 2u64.pow(32)) as u32 / 2939745 / 4;
@@ -324,7 +324,7 @@ pub const fn rd_to_date(n: i32) -> (i32, u32, u32) {
     let m = n / 2u32.pow(16);
     let d = n % 2u32.pow(16) / 2141;
     let y = (y as i32).wrapping_sub(YEAR_OFFSET);
-    let m = m - 12 * nd;
+    let m = if nd == 1 { m - 12 } else { m };
     let d = d + 1;
     (y, m, d)
 }


### PR DESCRIPTION
As per "Section 8 / First column" of the paper, we can replace
```
    let n = n % 146097 / 4;`
    let n = 4 * n + 3;
```
with
```
    let r = n % 146097;
    let n = r | 3;
```
which might improve the generated code. Unfortunately the Rust compiler doesn't seem to be able to do it on its own.

We can replace
```
    let m = m - 12 * nd;
```
with
```
    let m = if nd == 1 { m - 12 } else { m };
```

Fortunately, for the first expression above the compiler does not emit `imul` and it does not branch. Indeed, it uses a `cmovb` which is good. However, the same happens for the expression using the ternary operator. There's a difference though. Recall that `nd` is defined by
```
    let nd = (n >= 306) as u32;
```
and it is used in the calculation of `y` and `m`. For some reason, for the first expression, the compiler twice emits the `cmp` instruction to perform the (equivalent of the) comparison with `306`. For the second expression, only one `cmp` is emitted.

---

Disclaimer: I'm one of the authors of the paper on which `rd_to_date` is based.

I'm not a Rust programmer and I didn't even compiled this PR. However, I tried it on Compiler Explorer in [[1]](https://godbolt.org/z/745vo9e1P) and [[2]](https://godbolt.org/z/d7qnPo37s) which show the assembly for the original and modified version.

Notice that [[1]](https://godbolt.org/z/745vo9e1P)  contains an `and` (line 8) which is absent from [[2]](https://godbolt.org/z/d7qnPo37s). This comes from  `4 * (r / 4)` which simply resets the two rightmost bits of `r` to `0` -- so the use of `and`. However, these bits are immediately set to `1` by the following `or 3` and thus, the `and` is not necessary at all.

Notice also that [[1]](https://godbolt.org/z/745vo9e1P) contains two `cmp` instructions (lines 22 and 25) and [[2]](https://godbolt.org/z/d7qnPo37s) contains only one (line 22).

Finally, [[3]](https://godbolt.org/z/rasxxMhnq) and [[4]](https://godbolt.org/z/9eYWTPKfK) show the llvm-maca analysis for the two assemblies in  [[1]](https://godbolt.org/z/745vo9e1P) and [[2]](https://godbolt.org/z/d7qnPo37s). Amongst other things they show that the original code takes 33 cycles whereas the modified version takes 32 cycles. (Every little helps.)

[1] https://godbolt.org/z/745vo9e1P
[2] https://godbolt.org/z/d7qnPo37s
[3] https://godbolt.org/z/rasxxMhnq
[4] https://godbolt.org/z/9eYWTPKfK
