### PR TITLE
Use smaller datatypes where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,10 @@ algorithms available.
 ## Notes
 
 The library does not expose any kind of `Date` or `DateTime` structures, but
-simply tuples for the necessary values. There is bounds checking via
-`debug_assert`, which means that it is not present in release builds.
-Callers are required to do their own bounds checking where ever input
-require it. Datatypes are selected for performance and utility, rather than
-what is most natural for the value.
+simply tuples for the necessary values. Bounds checking is done via
+`debug_assert` only, which means the methods are guaranteed to not panic in
+release builds. Callers are required to do their own bounds checking.
+Datatypes are selected as the smallest that will fit the value.
 
 Currently the library implements algorithms for the [Proleptic Gregorian
 Calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar) which

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ which means a usable range of roughly -1,460,000 to 1,460,000 years.
 
 ## Benchmarks
 
-Results on GitHub Codespaces default VM:
+Results on GitHub Codespaces 8-core VM:
 
 | Function               | [datealgo](https://github.com/nakedible/datealgo-rs) | [hinnant](https://howardhinnant.github.io/date_algorithms.html) | [httpdate](https://github.com/pyfisch/httpdate) | [humantime](https://github.com/tailhook/humantime) | [time](https://github.com/time-rs/time) | [chrono](https://github.com/chronotope/chrono) |
 | ---------------------- | ------------- | --------- | --------- | --------- | --------- | --------- |
-| date_to_rd             | **3.1 ns**    | 3.9 ns    | 4.2 ns    | 3.8 ns    | 18.5 ns   | 8.6 ns    |
-| rd_to_date             | **5.0 ns**    | 9.6 ns    | 12.4 ns   | 12.3 ns   | 23.6 ns   | 10.1 ns   |
-| datetime_to_systemtime | **6.2 ns**    |           | 10.9 ns   | 10.1 ns   | 46.1 ns   | 47.5 ns   |
-| systemtime_to_datetime | **17.2 ns**   |           | 27.0 ns   | 26.8 ns   | 51.1 ns   | 216.8 ns  |
+| date_to_rd             | **2.5 ns**    | 3.3 ns    | 3.1 ns    | 3.2 ns    | 17.7 ns   | 7.4 ns    |
+| rd_to_date             | **3.7 ns**    | 7.1 ns    | 11.8 ns   | 11.9 ns   | 18.7 ns   | 8.7 ns    |
+| datetime_to_systemtime | **6.9 ns**    |           | 10.6 ns   | 9.6 ns    | 58.9 ns   | 50.7 ns   |
+| systemtime_to_datetime | **14.6 ns**   |           | 20.5 ns   | 20.3 ns   | 57.0 ns   | 228.2 ns  |
 
 Some code has been adapted from the libraries to produce comparable
 benchmarks.

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -12,24 +12,35 @@ fn bench_basic(c: &mut Criterion) {
     c.bench_function("secs_to_dhms", |b| b.iter(|| black_box(datealgo::secs_to_dhms(black_box(s)))));
     let dhms = (123123, 12, 34, 56);
     c.bench_function("dhms_to_secs", |b| b.iter(|| black_box(datealgo::dhms_to_secs(black_box(dhms)))));
-    c.bench_function("secs_to_datetime", |b| b.iter(|| black_box(datealgo::secs_to_datetime(black_box(s)))));
+    c.bench_function("secs_to_datetime", |b| {
+        b.iter(|| black_box(datealgo::secs_to_datetime(black_box(s))))
+    });
     let dt = (2023, 5, 20, 12, 34, 56);
-    c.bench_function("datetime_to_secs", |b| b.iter(|| black_box(datealgo::datetime_to_secs(black_box(dt)))));
+    c.bench_function("datetime_to_secs", |b| {
+        b.iter(|| black_box(datealgo::datetime_to_secs(black_box(dt))))
+    });
     let y = 2000;
     c.bench_function("is_leap_year", |b| b.iter(|| black_box(datealgo::is_leap_year(black_box(y)))));
     let m = 2;
-    c.bench_function("days_in_month", |b| b.iter(|| black_box(datealgo::days_in_month(black_box(y), black_box(m)))));
+    c.bench_function("days_in_month", |b| {
+        b.iter(|| black_box(datealgo::days_in_month(black_box(y), black_box(m))))
+    });
     let st = UNIX_EPOCH + Duration::from_secs(1684574678);
-    c.bench_function("systemtime_to_secs", |b| b.iter(|| black_box(datealgo::systemtime_to_secs(black_box(st)))));
+    c.bench_function("systemtime_to_secs", |b| {
+        b.iter(|| black_box(datealgo::systemtime_to_secs(black_box(st))))
+    });
     let sn = (1684574678, 0);
-    c.bench_function("secs_to_systemtime", |b| b.iter(|| black_box(datealgo::secs_to_systemtime(black_box(sn)))));
-    c.bench_function("systemtime_to_datetime", |b| b.iter(|| black_box(datealgo::systemtime_to_datetime(black_box(st)))));
+    c.bench_function("secs_to_systemtime", |b| {
+        b.iter(|| black_box(datealgo::secs_to_systemtime(black_box(sn))))
+    });
+    c.bench_function("systemtime_to_datetime", |b| {
+        b.iter(|| black_box(datealgo::systemtime_to_datetime(black_box(st))))
+    });
     let dtn = (2023, 5, 20, 12, 34, 56, 0);
-    c.bench_function("datetime_to_systemtime", |b| b.iter(|| black_box(datealgo::datetime_to_systemtime(black_box(dtn)))));
+    c.bench_function("datetime_to_systemtime", |b| {
+        b.iter(|| black_box(datealgo::datetime_to_systemtime(black_box(dtn))))
+    });
 }
 
-criterion_group!(
-    benches,
-    bench_basic,
-);
+criterion_group!(benches, bench_basic,);
 criterion_main!(benches);

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -21,31 +21,31 @@ mod datealgo_alt {
     }
 
     #[inline]
-    pub const fn rd_to_weekday2(n: i32) -> u32 {
-        (n + 4).rem_euclid(7) as u32
+    pub const fn rd_to_weekday2(n: i32) -> u8 {
+        (n + 4).rem_euclid(7) as u8
     }
 
     #[inline]
-    pub const fn rd_to_weekday3(n: i32) -> u32 {
+    pub const fn rd_to_weekday3(n: i32) -> u8 {
         if n >= -4 {
-            ((n + 4) % 7) as u32
+            ((n + 4) % 7) as u8
         } else {
-            ((n + 5) % 7 + 6) as u32
+            ((n + 5) % 7 + 6) as u8
         }
     }
 
     #[inline]
-    pub const fn date_to_weekday2((y, m, d): (i32, u32, u32)) -> u32 {
+    pub const fn date_to_weekday2((y, m, d): (i32, u8, u8)) -> u8 {
         datealgo::rd_to_weekday(datealgo::date_to_rd((y, m, d)))
     }
 
     #[inline]
-    pub const fn date_to_weekday3((year, month, day): (i32, u32, u32)) -> u32 {
+    pub const fn date_to_weekday3((year, month, day): (i32, u8, u8)) -> u8 {
         let year = year.wrapping_add(YEAR_OFFSET) as u32;
         let adjustment = (14 - month) / 12;
-        let mm = month + 12 * adjustment - 2;
-        let yy = year - adjustment;
-        (day + (13 * mm - 1) / 5 + yy + yy / 4 - yy / 100 + yy / 400 + 6) % 7 + 1
+        let mm = (month + 12 * adjustment - 2) as u32;
+        let yy = year - adjustment as u32;
+        ((day as u32 + (13 * mm - 1) / 5 + yy + yy / 4 - yy / 100 + yy / 400 + 6) % 7 + 1) as u8
     }
 
     #[cfg(feature = "std")]
@@ -67,7 +67,7 @@ mod httpdate {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[inline]
-    pub fn rd_to_date(n: i32) -> (i32, u32, u32) {
+    pub fn rd_to_date(n: i32) -> (i32, u8, u8) {
         /* 2000-03-01 (mod 400 year, immediately after feb29 */
         const LEAPOCH: i64 = 11017;
         const DAYS_PER_400Y: i64 = 365 * 400 + 97;
@@ -121,11 +121,11 @@ mod httpdate {
             mon + 2
         };
 
-        (year as i32, mon as u32, mday as u32)
+        (year as i32, mon as u8, mday as u8)
     }
 
     #[inline]
-    pub fn date_to_rd((y, m, d): (i32, u32, u32)) -> i32 {
+    pub fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
         fn is_leap_year(y: u16) -> bool {
             y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
         }
@@ -155,7 +155,7 @@ mod httpdate {
         days as i32
     }
 
-    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u32, u32, u8, u8, u8, u32) {
+    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u8, u8, u8, u8, u8, u32) {
         let dur = v.duration_since(UNIX_EPOCH).expect("all times should be after the epoch");
         let secs_since_epoch = dur.as_secs();
 
@@ -224,8 +224,8 @@ mod httpdate {
         // };
         (
             year as i32,
-            mon as u32,
-            mday as u32,
+            mon as u8,
+            mday as u8,
             (secs_of_day / 3600) as u8,
             ((secs_of_day % 3600) / 60) as u8,
             (secs_of_day % 60) as u8,
@@ -233,7 +233,7 @@ mod httpdate {
         )
     }
 
-    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u32, u32, u8, u8, u8, u32)) -> SystemTime {
+    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u8, u8, u8, u8, u8, u32)) -> SystemTime {
         fn is_leap_year(y: i32) -> bool {
             y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
         }
@@ -267,7 +267,7 @@ mod humantime {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[inline]
-    pub fn rd_to_date(n: i32) -> (i32, u32, u32) {
+    pub fn rd_to_date(n: i32) -> (i32, u8, u8) {
         /* 2000-03-01 (mod 400 year, immediately after feb29 */
         const LEAPOCH: i64 = 11017;
         const DAYS_PER_400Y: i64 = 365 * 400 + 97;
@@ -321,11 +321,11 @@ mod humantime {
             mon + 2
         };
 
-        (year as i32, mon as u32, mday as u32)
+        (year as i32, mon as u8, mday as u8)
     }
 
     #[inline]
-    pub fn date_to_rd((y, m, d): (i32, u32, u32)) -> i32 {
+    pub fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
         fn is_leap_year(y: u64) -> bool {
             y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
         }
@@ -359,7 +359,7 @@ mod humantime {
         days as i32
     }
 
-    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u32, u32, u8, u8, u8, u32)) -> SystemTime {
+    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u8, u8, u8, u8, u8, u32)) -> SystemTime {
         fn is_leap_year(y: u64) -> bool {
             y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
         }
@@ -403,7 +403,7 @@ mod humantime {
         UNIX_EPOCH + Duration::new(total_seconds, nsec)
     }
 
-    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u32, u32, u8, u8, u8, u32) {
+    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u8, u8, u8, u8, u8, u32) {
         let dur = v.duration_since(UNIX_EPOCH).expect("all times should be after the epoch");
         let secs_since_epoch = dur.as_secs();
 
@@ -464,7 +464,7 @@ mod humantime {
         (
             year as i32,
             mon,
-            mday as u32,
+            mday as u8,
             (secs_of_day / 3600) as u8,
             (secs_of_day / 60 % 60) as u8,
             (secs_of_day % 60) as u8,
@@ -478,19 +478,19 @@ mod chrono {
     use std::time::SystemTime;
 
     #[inline]
-    pub fn rd_to_date(n: i32) -> (i32, u32, u32) {
+    pub fn rd_to_date(n: i32) -> (i32, u8, u8) {
         let date = chrono::NaiveDate::from_num_days_from_ce_opt(n + 719162).unwrap();
-        (date.year(), date.month(), date.day())
+        (date.year(), date.month() as u8, date.day() as u8)
     }
 
     #[inline]
-    pub fn date_to_rd((y, m, d): (i32, u32, u32)) -> i32 {
-        let days = chrono::NaiveDate::from_ymd_opt(y, m, d).unwrap().num_days_from_ce();
+    pub fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
+        let days = chrono::NaiveDate::from_ymd_opt(y, m as u32, d as u32).unwrap().num_days_from_ce();
         days - 719162
     }
 
     #[inline]
-    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u32, u32, u8, u8, u8, u32)) -> SystemTime {
+    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u8, u8, u8, u8, u8, u32)) -> SystemTime {
         chrono::NaiveDate::from_ymd_opt(y as i32, m as u32, d as u32)
             .unwrap()
             .and_hms_nano_opt(hh as u32, mm as u32, ss as u32, nsec)
@@ -501,12 +501,12 @@ mod chrono {
     }
 
     #[inline]
-    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u32, u32, u8, u8, u8, u32) {
+    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u8, u8, u8, u8, u8, u32) {
         let d: chrono::DateTime<chrono::Utc> = v.into();
         (
             d.year() as i32,
-            d.month(),
-            d.day(),
+            d.month() as u8,
+            d.day() as u8,
             d.hour() as u8,
             d.minute() as u8,
             d.second() as u8,
@@ -521,13 +521,13 @@ mod time {
     const UNIX_EPOCH_JULIAN_DAY: i32 = 2440588;
 
     #[inline]
-    pub fn rd_to_date(n: i32) -> (i32, u32, u32) {
+    pub fn rd_to_date(n: i32) -> (i32, u8, u8) {
         let date = time::Date::from_julian_day(n + UNIX_EPOCH_JULIAN_DAY).unwrap();
-        (date.year(), date.month() as u32, date.day() as u32)
+        (date.year(), date.month() as u8, date.day() as u8)
     }
 
     #[inline]
-    pub fn date_to_rd((y, m, d): (i32, u32, u32)) -> i32 {
+    pub fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
         time::Date::from_calendar_date(y, time::Month::try_from(m as u8).unwrap(), d as u8)
             .unwrap()
             .to_julian_day()
@@ -535,7 +535,7 @@ mod time {
     }
 
     #[inline]
-    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u32, u32, u8, u8, u8, u32)) -> SystemTime {
+    pub fn datetime_to_systemtime((y, m, d, hh, mm, ss, nsec): (i32, u8, u8, u8, u8, u8, u32)) -> SystemTime {
         time::Date::from_calendar_date(y, time::Month::try_from(m as u8).unwrap(), d as u8)
             .unwrap()
             .with_hms_nano(hh, mm, ss, nsec)
@@ -545,12 +545,12 @@ mod time {
     }
 
     #[inline]
-    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u32, u32, u8, u8, u8, u32) {
+    pub fn systemtime_to_datetime(v: SystemTime) -> (i32, u8, u8, u8, u8, u8, u32) {
         let d: time::OffsetDateTime = v.into();
         (
             d.year() as i32,
-            d.month() as u32,
-            d.day() as u32,
+            d.month() as u8,
+            d.day() as u8,
             d.hour() as u8,
             d.minute() as u8,
             d.second() as u8,
@@ -560,7 +560,7 @@ mod time {
 }
 
 mod hinnant {
-    pub fn days_from_civil((y, m, d): (i32, u32, u32)) -> i32 {
+    pub fn days_from_civil((y, m, d): (i32, u8, u8)) -> i32 {
         let y = y as i32 - (m <= 2) as i32;
         let era = y.div_euclid(400);
         let yoe = y.rem_euclid(400) as u32;
@@ -569,7 +569,7 @@ mod hinnant {
         era * 146097 + doe as i32 - 719468
     }
 
-    pub fn days_from_civil_u((y, m, d): (i32, u32, u32)) -> i32 {
+    pub fn days_from_civil_u((y, m, d): (i32, u8, u8)) -> i32 {
         let y = y as u32 - (m <= 2) as u32;
         let era = y.div_euclid(400);
         let yoe = y.rem_euclid(400) as u32;
@@ -578,7 +578,7 @@ mod hinnant {
         (era * 146097 + doe as u32 - 719468) as i32
     }
 
-    pub fn civil_from_days(n: i32) -> (i32, u32, u32) {
+    pub fn civil_from_days(n: i32) -> (i32, u8, u8) {
         let z = n + 719468;
         let era = z.div_euclid(146097);
         let doe = z.rem_euclid(146097) as u32;
@@ -588,10 +588,10 @@ mod hinnant {
         let mp = (5 * doy + 2) / 153;
         let d = doy - (153 * mp + 2) / 5 + 1;
         let m = if mp < 10 { mp + 3 } else { mp - 9 };
-        (y + (m <= 2) as i32, m as u32, d as u32)
+        (y + (m <= 2) as i32, m as u8, d as u8)
     }
 
-    pub fn civil_from_days_u(n: i32) -> (i32, u32, u32) {
+    pub fn civil_from_days_u(n: i32) -> (i32, u8, u8) {
         let z = (n + 719468) as u32;
         let era = z.div_euclid(146097);
         let doe = z.rem_euclid(146097) as u32;
@@ -601,7 +601,7 @@ mod hinnant {
         let mp = (5 * doy + 2) / 153;
         let d = doy - (153 * mp + 2) / 5 + 1;
         let m = if mp < 10 { mp + 3 } else { mp - 9 };
-        ((y + (m <= 2) as u32) as i32, m as u32, d as u32)
+        ((y + (m <= 2) as u32) as i32, m as u8, d as u8)
     }
 }
 

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -2,8 +2,8 @@ use iai_callgrind::{black_box, main};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[inline(never)]
-fn iai_rd_to_date() -> (i32, u32, u32) {
-    datealgo::rd_to_date(black_box(12345))
+fn iai_rd_to_date() -> (i32, u8, u8) {
+    datealgo::rd_to_date(black_box(19489))
 }
 
 #[inline(never)]
@@ -12,12 +12,12 @@ fn iai_date_to_rd() -> i32 {
 }
 
 #[inline(never)]
-fn iai_rd_to_weekday() -> u32 {
-    datealgo::rd_to_weekday(black_box(12345))
+fn iai_rd_to_weekday() -> u8 {
+    datealgo::rd_to_weekday(black_box(19489))
 }
 
 #[inline(never)]
-fn iai_date_to_weekday() -> u32 {
+fn iai_date_to_weekday() -> u8 {
     datealgo::date_to_weekday(black_box((2023, 5, 12)))
 }
 
@@ -28,11 +28,11 @@ fn iai_secs_to_dhms() -> (i32, u8, u8, u8) {
 
 #[inline(never)]
 fn iai_dhms_to_secs() -> i64 {
-    datealgo::dhms_to_secs(black_box((123123, 12, 34, 56)))
+    datealgo::dhms_to_secs(black_box((19489, 12, 34, 56)))
 }
 
 #[inline(never)]
-fn iai_secs_to_datetime() -> (i32, u32, u32, u8, u8, u8) {
+fn iai_secs_to_datetime() -> (i32, u8, u8, u8, u8, u8) {
     datealgo::secs_to_datetime(black_box(1684574678i64))
 }
 
@@ -47,7 +47,7 @@ fn iai_is_leap_year() -> bool {
 }
 
 #[inline(never)]
-fn iai_days_in_month() -> u32 {
+fn iai_days_in_month() -> u8 {
     datealgo::days_in_month(black_box(2000), black_box(2))
 }
 
@@ -62,7 +62,7 @@ fn iai_secs_to_systemtime() -> SystemTime {
 }
 
 #[inline(never)]
-fn iai_systemtime_to_datetime() -> Option<(i32, u32, u32, u8, u8, u8, u32)> {
+fn iai_systemtime_to_datetime() -> Option<(i32, u8, u8, u8, u8, u8, u32)> {
     datealgo::systemtime_to_datetime(black_box(UNIX_EPOCH + Duration::from_secs(1684574678)))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,11 @@ pub const fn dhms_to_secs((d, h, m, s): (i32, u8, u8, u8)) -> i64 {
     debug_assert!(h >= consts::HOUR_MIN && h <= consts::HOUR_MAX, "given hour is out of range");
     debug_assert!(m >= consts::MINUTE_MIN && m <= consts::MINUTE_MAX, "given minute is out of range");
     debug_assert!(s >= consts::SECOND_MIN && s <= consts::SECOND_MAX, "given second is out of range");
-    d as i64 * SECS_IN_DAY + h as i64 * 3600 + m as i64 * 60 + s as i64
+    if d >= RD_MIN && d <= RD_MAX {
+        d as i64 * SECS_IN_DAY + h as i64 * 3600 + m as i64 * 60 + s as i64
+    } else {
+        0
+    }
 }
 
 /// Convert total seconds to year, month, day, hours, minutes and seconds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ pub mod consts {
 /// Given a day counting from Unix epoch (January 1st, 1970) returns a `(year,
 /// month, day)` tuple.
 ///
-/// # Errors
+/// # Panics
 ///
 /// Argument must be between [RD_MIN] and [RD_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
@@ -333,10 +333,10 @@ pub const fn rd_to_date(n: i32) -> (i32, u8, u8) {
 /// Given a `(year, month, day)` tuple returns the days since Unix epoch
 /// (January 1st, 1970). Dates before the epoch produce negative values.
 ///
-/// # Errors
+/// # Panics
 ///
-/// Year must be between [YEAR_MIN] and [YEAR_MAX], month must be between `1`
-/// and `12` and day must be between `1` and the number of days in the month in
+/// Year must be between [YEAR_MIN] and [YEAR_MAX]. Month must be between `1`
+/// and `12`. Day must be between `1` and the number of days in the month in
 /// question. Bounds are checked using `debug_assert` only, so that the checks
 /// are not present in release builds, similar to integer overflow checks.
 ///
@@ -384,7 +384,7 @@ pub const fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
 /// week. Day of week is given as `u32` number between 1 and 7, with `1` meaning
 /// Monday and `7` meaning Sunday.
 ///
-/// # Errors
+/// # Panics
 ///
 /// Argument must be between [RD_MIN] and [RD_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
@@ -426,11 +426,12 @@ pub const fn rd_to_weekday(n: i32) -> u8 {
 /// given as `u32` number between 1 and 7, with `1` meaning Monday and `7`
 /// meaning Sunday.
 ///
-/// # Errors
+/// # Panics
 ///
-/// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
-/// using `debug_assert` only, so that the checks are not present in release
-/// builds, similar to integer overflow checks.
+/// Year must be between [YEAR_MIN] and [YEAR_MAX]. Month must be between `1`
+/// and `12`. Day must be between `1` and the number of days in the month in
+/// question. Bounds are checked using `debug_assert` only, so that the checks
+/// are not present in release builds, similar to integer overflow checks.
 ///
 /// # Examples
 ///
@@ -467,7 +468,7 @@ pub const fn date_to_weekday((y, m, d): (i32, u8, u8)) -> u8 {
 /// Given seconds counting from Unix epoch (January 1st, 1970) returns a `(days,
 /// hours, minutes, seconds)` tuple.
 ///
-/// # Errors
+/// # Panics
 ///
 /// Argument must be between [RD_SECONDS_MIN] and [RD_SECONDS_MAX] inclusive.
 /// Bounds are checked using `debug_assert` only, so that the checks are not
@@ -510,11 +511,13 @@ pub const fn secs_to_dhms(secs: i64) -> (i32, u8, u8, u8) {
 /// Given a `(days, hours, minutes, seconds)` tuple from Unix epoch (January
 /// 1st, 1970) returns the total seconds.
 ///
-/// # Errors
+/// # Panics
 ///
-/// Days must be between [RD_MIN] and [RD_MAX] inclusive. Bounds are checked
-/// using `debug_assert` only, so that the checks are not present in release
-/// builds, similar to integer overflow checks.
+/// Days must be between [RD_MIN] and [RD_MAX] inclusive. Hours must be between
+/// `0` and `23`. Minutes must be between `0` and `59`. Seconds must be between
+/// `0` and `59`. Bounds are checked using `debug_assert` only, so that the
+/// checks are not present in release builds, similar to integer overflow
+/// checks.
 ///
 /// # Examples
 ///
@@ -546,7 +549,7 @@ pub const fn dhms_to_secs((d, h, m, s): (i32, u8, u8, u8)) -> i64 {
 /// Given seconds counting from Unix epoch (January 1st, 1970) returns a `(year,
 /// month, day, hours, minutes, seconds)` tuple.
 ///
-/// # Errors
+/// # Panics
 ///
 /// Argument must be between [RD_SECONDS_MIN] and [RD_SECONDS_MAX] inclusive.
 /// Bounds are checked using `debug_assert` only, so that the checks are not
@@ -579,11 +582,14 @@ pub const fn secs_to_datetime(secs: i64) -> (i32, u8, u8, u8, u8, u8) {
 /// Given a `(year, month, day, hours, minutes, seconds)` tuple from Unix epoch
 /// (January 1st, 1970) returns the total seconds.
 ///
-/// # Errors
+/// # Panics
 ///
-/// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
-/// using `debug_assert` only, so that the checks are not present in release
-/// builds, similar to integer overflow checks.
+/// Year must be between [YEAR_MIN] and [YEAR_MAX]. Month must be between `1`
+/// and `12`. Day must be between `1` and the number of days in the month in
+/// question. Hours must be between `0` and `23`. Minutes must be between `0`
+/// and `59`. Seconds must be between `0` and `59`. Bounds are checked using
+/// `debug_assert` only, so that the checks are not present in release builds,
+/// similar to integer overflow checks.
 ///
 /// # Examples
 ///
@@ -609,6 +615,12 @@ pub const fn datetime_to_secs((y, m, d, hh, mm, ss): (i32, u8, u8, u8, u8, u8)) 
 
 /// Determine if the given year is a leap year
 ///
+/// # Panics
+///
+/// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
+/// using `debug_assert` only, so that the checks are not present in release
+/// builds, similar to integer overflow checks.
+///
 /// # Examples
 ///
 /// ```
@@ -631,6 +643,12 @@ pub const fn is_leap_year(y: i32) -> bool {
 }
 
 /// Determine the number of days in the given month in the given year
+///
+/// # Panics
+///
+/// Year must be between [YEAR_MIN] and [YEAR_MAX]. Month must be between `1`
+/// and `12`. Bounds are checked using `debug_assert` only, so that the checks
+/// are not present in release builds, similar to integer overflow checks.
 ///
 /// # Example
 ///
@@ -724,11 +742,12 @@ pub fn systemtime_to_secs(st: SystemTime) -> Option<(i64, u32)> {
 /// Given a tuple of seconds and nanoseconds counting from Unix epoch (January
 /// 1st, 1970) returns [`std::time::SystemTime`].
 ///
-/// # Errors
+/// # Panics
 ///
 /// Seconds must be between [RD_SECONDS_MIN] and [RD_SECONDS_MAX] inclusive.
-/// Bounds are checked using `debug_assert` only, so that the checks are not
-/// present in release builds, similar to integer overflow checks.
+/// Nanoseconds must between `0` and `999_999_999`. Bounds are checked using
+/// `debug_assert` only, so that the checks are not present in release builds,
+/// similar to integer overflow checks.
 ///
 /// # Examples
 ///
@@ -805,11 +824,15 @@ pub fn systemtime_to_datetime(st: SystemTime) -> Option<(i32, u8, u8, u8, u8, u8
 /// Given a `(year, month, day, hours, minutes, seconds, nanoseconds)` tuple
 /// from Unix epoch (January 1st, 1970) returns [`std::time::SystemTime`].
 ///
-/// # Errors
+/// # Panics
 ///
-/// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
-/// using `debug_assert` only, so that the checks are not present in release
-/// builds, similar to integer overflow checks.
+/// Year must be between [YEAR_MIN] and [YEAR_MAX]. Month must be between `1`
+/// and `12`. Day must be between `1` and the number of days in the month in
+/// question. Hours must be between `0` and `23`. Minutes must be between `0`
+/// and `59`. Seconds must be between `0` and `59`. Nanoseconds must be between
+/// `0` and `999_999_999`. Bounds are checked using `debug_assert` only, so that
+/// the checks are not present in release builds, similar to integer overflow
+/// checks.
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,10 @@
 //! # Notes
 //!
 //! The library does not expose any kind of `Date` or `DateTime` structures, but
-//! simply tuples for the necessary values. There is bounds checking via
-//! `debug_assert`, which means that it is not present in release builds.
-//! Callers are required to do their own bounds checking where ever input
-//! require it. Datatypes are selected as smallest that will fit the value to
-//! allow the compiler maximum freedom in optimizing.
+//! simply tuples for the necessary values. Bounds checking is done via
+//! `debug_assert` only, which means the methods are guaranteed to not panic in
+//! release builds. Callers are required to do their own bounds checking.
+//! Datatypes are selected as the smallest that will fit the value.
 //!
 //! Currently the library implements algorithms for the [Proleptic Gregorian
 //! Calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar) which
@@ -93,22 +92,22 @@
 //!
 //! # Benchmarks
 //!
-//! Results on GitHub Codespaces default VM:
+//! Results on GitHub Codespaces 8-core VM:
 //!
 //! | Function               | [datealgo](https://github.com/nakedible/datealgo-rs) | [hinnant](https://howardhinnant.github.io/date_algorithms.html) | [httpdate](https://github.com/pyfisch/httpdate) | [humantime](https://github.com/tailhook/humantime) | [time](https://github.com/time-rs/time) | [chrono](https://github.com/chronotope/chrono) |
 //! | ---------------------- | ------------- | --------- | --------- | --------- | --------- | --------- |
-//! | date_to_rd             | **3.1 ns**    | 3.9 ns    | 4.2 ns    | 3.8 ns    | 18.5 ns   | 8.6 ns    |
-//! | rd_to_date             | **5.0 ns**    | 9.6 ns    | 12.4 ns   | 12.3 ns   | 23.6 ns   | 10.1 ns   |
-//! | datetime_to_systemtime | **6.2 ns**    |           | 10.9 ns   | 10.1 ns   | 46.1 ns   | 47.5 ns   |
-//! | systemtime_to_datetime | **17.2 ns**   |           | 27.0 ns   | 26.8 ns   | 51.1 ns   | 216.8 ns  |
+//! | date_to_rd             | **2.5 ns**    | 3.3 ns    | 3.1 ns    | 3.2 ns    | 17.7 ns   | 7.4 ns    |
+//! | rd_to_date             | **3.7 ns**    | 7.1 ns    | 11.8 ns   | 11.9 ns   | 18.7 ns   | 8.7 ns    |
+//! | datetime_to_systemtime | **6.9 ns**    |           | 10.6 ns   | 9.6 ns    | 58.9 ns   | 50.7 ns   |
+//! | systemtime_to_datetime | **14.6 ns**   |           | 20.5 ns   | 20.3 ns   | 57.0 ns   | 228.2 ns  |
 //!
 //! Some code has been adapted from the libraries to produce comparable
 //! benchmarks.
-//! 
+//!
 //! # Acknowledgements
-//! 
+//!
 //! I do not claim original research on anything that is in this crate.
-//! 
+//!
 //! - [Cassio Neri and Lorenz
 //!   Schneider](https://onlinelibrary.wiley.com/doi/full/10.1002/spe.3172):
 //!   While searching for best method for date conversion, I stumbled upon a
@@ -279,9 +278,9 @@ pub mod consts {
 ///
 /// Given a day counting from Unix epoch (January 1st, 1970) returns a `(year,
 /// month, day)` tuple.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Argument must be between [RD_MIN] and [RD_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
 /// builds, similar to integer overflow checks.
@@ -333,9 +332,9 @@ pub const fn rd_to_date(n: i32) -> (i32, u8, u8) {
 ///
 /// Given a `(year, month, day)` tuple returns the days since Unix epoch
 /// (January 1st, 1970). Dates before the epoch produce negative values.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Year must be between [YEAR_MIN] and [YEAR_MAX], month must be between `1`
 /// and `12` and day must be between `1` and the number of days in the month in
 /// question. Bounds are checked using `debug_assert` only, so that the checks
@@ -384,9 +383,9 @@ pub const fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
 /// Given a day counting from Unix epoch (January 1st, 1970) returns the day of
 /// week. Day of week is given as `u32` number between 1 and 7, with `1` meaning
 /// Monday and `7` meaning Sunday.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Argument must be between [RD_MIN] and [RD_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
 /// builds, similar to integer overflow checks.
@@ -426,9 +425,9 @@ pub const fn rd_to_weekday(n: i32) -> u8 {
 /// Given a `(year, month, day)` tuple returns the day of week. Day of week is
 /// given as `u32` number between 1 and 7, with `1` meaning Monday and `7`
 /// meaning Sunday.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
 /// builds, similar to integer overflow checks.
@@ -456,7 +455,7 @@ pub const fn rd_to_weekday(n: i32) -> u8 {
 /// # Algorithm
 ///
 /// Simply converts date to rata die and then rata die to weekday.
-/// 
+///
 #[inline]
 pub const fn date_to_weekday((y, m, d): (i32, u8, u8)) -> u8 {
     let rd = date_to_rd((y, m, d));
@@ -467,9 +466,9 @@ pub const fn date_to_weekday((y, m, d): (i32, u8, u8)) -> u8 {
 ///
 /// Given seconds counting from Unix epoch (January 1st, 1970) returns a `(days,
 /// hours, minutes, seconds)` tuple.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Argument must be between [RD_SECONDS_MIN] and [RD_SECONDS_MAX] inclusive.
 /// Bounds are checked using `debug_assert` only, so that the checks are not
 /// present in release builds, similar to integer overflow checks.
@@ -510,9 +509,9 @@ pub const fn secs_to_dhms(secs: i64) -> (i32, u8, u8, u8) {
 ///
 /// Given a `(days, hours, minutes, seconds)` tuple from Unix epoch (January
 /// 1st, 1970) returns the total seconds.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Days must be between [RD_MIN] and [RD_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
 /// builds, similar to integer overflow checks.
@@ -546,9 +545,9 @@ pub const fn dhms_to_secs((d, h, m, s): (i32, u8, u8, u8)) -> i64 {
 ///
 /// Given seconds counting from Unix epoch (January 1st, 1970) returns a `(year,
 /// month, day, hours, minutes, seconds)` tuple.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Argument must be between [RD_SECONDS_MIN] and [RD_SECONDS_MAX] inclusive.
 /// Bounds are checked using `debug_assert` only, so that the checks are not
 /// present in release builds, similar to integer overflow checks.
@@ -579,9 +578,9 @@ pub const fn secs_to_datetime(secs: i64) -> (i32, u8, u8, u8, u8, u8) {
 ///
 /// Given a `(year, month, day, hours, minutes, seconds)` tuple from Unix epoch
 /// (January 1st, 1970) returns the total seconds.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
 /// builds, similar to integer overflow checks.
@@ -669,9 +668,9 @@ pub const fn days_in_month(y: i32, m: u8) -> u8 {
 ///
 /// Given [`std::time::SystemTime`] returns an `Option` of `(seconds,
 /// nanoseconds)` tuple from Unix epoch (January 1st, 1970).
-/// 
+///
 /// # Errors
-/// 
+///
 /// Returns `None` if the time is before [RD_SECONDS_MIN] or after
 /// [RD_SECONDS_MAX].
 ///
@@ -724,9 +723,9 @@ pub fn systemtime_to_secs(st: SystemTime) -> Option<(i64, u32)> {
 ///
 /// Given a tuple of seconds and nanoseconds counting from Unix epoch (January
 /// 1st, 1970) returns [`std::time::SystemTime`].
-/// 
+///
 /// # Errors
-/// 
+///
 /// Seconds must be between [RD_SECONDS_MIN] and [RD_SECONDS_MAX] inclusive.
 /// Bounds are checked using `debug_assert` only, so that the checks are not
 /// present in release builds, similar to integer overflow checks.
@@ -770,9 +769,9 @@ pub fn secs_to_systemtime((secs, nsecs): (i64, u32)) -> SystemTime {
 ///
 /// Given [`std::time::SystemTime`] returns an Option of `(year, month, day,
 /// hours, minutes, seconds, nanoseconds)` tuple.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Returns `None` if the time is before [RD_SECONDS_MIN] or after
 /// [RD_SECONDS_MAX].
 ///
@@ -805,9 +804,9 @@ pub fn systemtime_to_datetime(st: SystemTime) -> Option<(i32, u8, u8, u8, u8, u8
 ///
 /// Given a `(year, month, day, hours, minutes, seconds, nanoseconds)` tuple
 /// from Unix epoch (January 1st, 1970) returns [`std::time::SystemTime`].
-/// 
+///
 /// # Errors
-/// 
+///
 /// Year must be between [YEAR_MIN] and [YEAR_MAX] inclusive. Bounds are checked
 /// using `debug_assert` only, so that the checks are not present in release
 /// builds, similar to integer overflow checks.

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -6,12 +6,12 @@ quickcheck! {
     fn quickcheck_rd_to_date(d: time::Date) -> TestResult {
         let rd = d.to_julian_day() - 2440588;
         let a = rd_to_date(rd);
-        let b = (d.year() as i32, d.month() as u32, d.day() as u32);
+        let b = (d.year() as i32, d.month() as u8, d.day() as u8);
         TestResult::from_bool(a == b)
     }
 
     fn quickcheck_date_to_rd(d: time::Date) -> TestResult {
-        let a = (d.year() as i32, d.month() as u32, d.day() as u32);
+        let a = (d.year() as i32, d.month() as u8, d.day() as u8);
         let rd = date_to_rd(a);
         TestResult::from_bool(rd == d.to_julian_day() - 2440588)
     }
@@ -36,8 +36,8 @@ quickcheck! {
         let a = systemtime_to_datetime(s.into()).unwrap();
         let b = (
             s.year() as i32,
-            s.month() as u32,
-            s.day() as u32,
+            s.month() as u8,
+            s.day() as u8,
             s.hour() as u8,
             s.minute() as u8,
             s.second() as u8,
@@ -50,8 +50,8 @@ quickcheck! {
         let s = s.assume_utc();
         let dt = (
             s.year() as i32,
-            s.month() as u32,
-            s.day() as u32,
+            s.month() as u8,
+            s.day() as u8,
             s.hour() as u8,
             s.minute() as u8,
             s.second() as u8,


### PR DESCRIPTION
Improves performance for some methods in benchmarks, hurts performance for some methods in benchmarks. Overall impact maybe a bit positive. However, since the code is meant to be inlined, real world impacts probably should be minimal. A judgement call I've been musing for quite some time.