### PR TITLE
feat: Make conversion to `SystemTime` be fallible

### DIFF
--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -57,7 +57,7 @@ fn iai_systemtime_to_secs() -> Option<(i64, u32)> {
 }
 
 #[inline(never)]
-fn iai_secs_to_systemtime() -> SystemTime {
+fn iai_secs_to_systemtime() -> Option<SystemTime> {
     datealgo::secs_to_systemtime(black_box((1684574678, 0)))
 }
 
@@ -67,7 +67,7 @@ fn iai_systemtime_to_datetime() -> Option<(i32, u8, u8, u8, u8, u8, u32)> {
 }
 
 #[inline(never)]
-fn iai_datetime_to_systemtime() -> SystemTime {
+fn iai_datetime_to_systemtime() -> Option<SystemTime> {
     datealgo::datetime_to_systemtime(black_box((2023, 5, 20, 12, 34, 56, 0)))
 }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -182,14 +182,14 @@ fn test_systemtime_to_secs() {
 
 #[test]
 fn test_secs_to_systemtime() {
-    assert_eq!(secs_to_systemtime((0, 0)), UNIX_EPOCH);
+    assert_eq!(secs_to_systemtime((0, 0)), Some(UNIX_EPOCH));
     assert_eq!(
         secs_to_systemtime((RD_SECONDS_MAX, 0)),
-        UNIX_EPOCH + Duration::from_secs(RD_SECONDS_MAX as u64)
+        UNIX_EPOCH.checked_add(Duration::from_secs(RD_SECONDS_MAX as u64))
     );
     assert_eq!(
         secs_to_systemtime((RD_SECONDS_MIN, 0)),
-        UNIX_EPOCH - Duration::from_secs(-RD_SECONDS_MIN as u64)
+        UNIX_EPOCH.checked_sub(Duration::from_secs(-RD_SECONDS_MIN as u64))
     );
 }
 
@@ -216,13 +216,13 @@ fn test_systemtime_to_datetime() {
 
 #[test]
 fn test_datetime_to_systemtime() {
-    assert_eq!(datetime_to_systemtime((1970, 1, 1, 0, 0, 0, 0)), UNIX_EPOCH);
+    assert_eq!(datetime_to_systemtime((1970, 1, 1, 0, 0, 0, 0)), Some(UNIX_EPOCH));
     assert_eq!(
         datetime_to_systemtime((YEAR_MAX, 12, 31, 23, 59, 59, 0)),
-        UNIX_EPOCH + Duration::from_secs(RD_SECONDS_MAX as u64)
+        UNIX_EPOCH.checked_add(Duration::from_secs(RD_SECONDS_MAX as u64))
     );
     assert_eq!(
         datetime_to_systemtime((YEAR_MIN, 1, 1, 0, 0, 0, 0)),
-        UNIX_EPOCH - Duration::from_secs(-RD_SECONDS_MIN as u64)
+        UNIX_EPOCH.checked_sub(Duration::from_secs(-RD_SECONDS_MIN as u64))
     );
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -57,7 +57,7 @@ quickcheck! {
             s.second() as u8,
             s.nanosecond(),
         );
-        let a = datetime_to_systemtime(dt);
+        let a = datetime_to_systemtime(dt).unwrap();
         let b: std::time::SystemTime = s.into();
         TestResult::from_bool(a == b)
     }


### PR DESCRIPTION
No performance impact.