### PR TITLE
More accurate benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ which means a usable range of roughly -1,460,000 to 1,460,000 years.
 
 ## Benchmarks
 
-Results on GitHub Codespaces 8-core VM:
+Results on Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz:
 
 | Function | [datealgo](https://github.com/nakedible/datealgo-rs) | [hinnant](https://howardhinnant.github.io/date_algorithms.html) | [httpdate](https://github.com/pyfisch/httpdate) | [humantime](https://github.com/tailhook/humantime) | [time](https://github.com/time-rs/time) | [chrono](https://github.com/chronotope/chrono) |
 | ---------------------- | ------------- | --------- | --------- | --------- | --------- | --------- |
-| date_to_rd | **2.3 ns** | 4 ns | 3.2 ns | 3.2 ns | 17.7 ns | 7.2 ns |
-| rd_to_date | **3.6 ns** | 9.3 ns | 11.3 ns | 11.3 ns | 18.8 ns | 8.2 ns |
-| datetime_to_systemtime | **8.6 ns** | | 9.9 ns | 9.8 ns | 57.3 ns | 50.1 ns |
-| systemtime_to_datetime | **14.2 ns** | | 18.9 ns | 19 ns | 54.6 ns | 226.4 ns |
+| date_to_rd | **2.1 ns** | 3.3 ns | 3.3 ns | 3.6 ns | 15.1 ns | 6.5 ns |
+| rd_to_date | **3.2 ns** | 7.6 ns | 13.5 ns | 13.5 ns | 24.3 ns | 8 ns |
+| datetime_to_systemtime | **5.1 ns** | | 8.8 ns | 9 ns | 31.3 ns | 22.8 ns |
+| systemtime_to_datetime | **17.8 ns** | | 28.4 ns | 30.9 ns | 44.1 ns | 98.4 ns |
 
 Some code has been adapted from the libraries to produce comparable
 benchmarks.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,12 @@ Results on Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz:
 | datetime_to_systemtime | **5.1 ns** | | 8.8 ns | 9 ns | 31.3 ns | 22.8 ns |
 | systemtime_to_datetime | **17.8 ns** | | 28.4 ns | 30.9 ns | 44.1 ns | 98.4 ns |
 
-Some code has been adapted from the libraries to produce comparable
-benchmarks.
+Reliable and reproducible microbenchmarks are extremely hard to obtain with
+modern processors. And even then, they are of limited use as the surrounding
+code will dictate a lot about the performance. These benchmarks are not
+meant to be authoritative, but rather illustrate the likely relative speed
+differences of the algorithms. Your mileage will vary, so always benchmark
+the real use case.
 
 ## Acknowledgements
 

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,16 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
-fn bencher<I: Copy, O>(s: impl Fn() -> I, f: impl Fn(I) -> O) -> impl Fn(u64) -> Duration {
-    move |n| {
-        let v = s();
-        let now = Instant::now();
-        for _ in 0..n {
-            let _ = black_box(f(v));
-        }
-        now.elapsed()
-    }
-}
+mod util;
+use util::bencher;
 
 fn rand_year() -> i32 {
     fastrand::i32(datealgo::YEAR_MIN..=datealgo::YEAR_MAX)
@@ -77,6 +69,9 @@ fn rand_iwd() -> (i32, u8, u8) {
 }
 
 fn bench_basic(c: &mut Criterion) {
+    c.bench_function("overhead", |b| {
+        b.iter_custom(bencher(rand_date, |d| black_box(d)));
+    });
     c.bench_function("rd_to_date", |b| {
         b.iter_custom(bencher(rand_rd, |rd| datealgo::rd_to_date(black_box(rd))))
     });

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,16 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
-fn bencher<I: Copy, O>(s: impl Fn() -> I, f: impl Fn(I) -> O) -> impl Fn(u64) -> Duration {
-    move |n| {
-        let v = s();
-        let now = Instant::now();
-        for _ in 0..n {
-            let _ = black_box(f(v));
-        }
-        now.elapsed()
-    }
-}
+mod util;
+use util::bencher;
 
 fn rand_year() -> i32 {
     fastrand::i32(1970..=9999)

--- a/benches/util.rs
+++ b/benches/util.rs
@@ -1,0 +1,13 @@
+use criterion::black_box;
+use std::time::{Duration, Instant};
+
+pub fn bencher<I: Copy, O>(s: impl Fn() -> I, f: impl Fn(I) -> O) -> impl Fn(u64) -> Duration {
+    move |n| {
+        let v = s();
+        let now = Instant::now();
+        for _ in 0..n {
+            let _ = black_box(f(v));
+        }
+        now.elapsed()
+    }
+}

--- a/benches/util.rs
+++ b/benches/util.rs
@@ -2,11 +2,13 @@ use criterion::black_box;
 use std::time::{Duration, Instant};
 
 pub fn bencher<I: Copy, O>(s: impl Fn() -> I, f: impl Fn(I) -> O) -> impl Fn(u64) -> Duration {
+    const ARR_SIZE: usize = 4096;
     move |n| {
-        let v = s();
+        fastrand::seed(7);
+        let is: [I; ARR_SIZE] = std::array::from_fn(|_| s());
         let now = Instant::now();
-        for _ in 0..n {
-            let _ = black_box(f(v));
+        for i in 0..n {
+            let _ = black_box(f(is[i as usize & (ARR_SIZE-1)]));
         }
         now.elapsed()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,12 @@
 //! | datetime_to_systemtime | **5.1 ns** | | 8.8 ns | 9 ns | 31.3 ns | 22.8 ns |
 //! | systemtime_to_datetime | **17.8 ns** | | 28.4 ns | 30.9 ns | 44.1 ns | 98.4 ns |
 //!
-//! Some code has been adapted from the libraries to produce comparable
-//! benchmarks.
+//! Reliable and reproducible microbenchmarks are extremely hard to obtain with
+//! modern processors. And even then, they are of limited use as the surrounding
+//! code will dictate a lot about the performance. These benchmarks are not
+//! meant to be authoritative, but rather illustrate the likely relative speed
+//! differences of the algorithms. Your mileage will vary, so always benchmark
+//! the real use case.
 //!
 //! # Acknowledgements
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,14 +92,14 @@
 //!
 //! # Benchmarks
 //!
-//! Results on GitHub Codespaces 8-core VM:
+//! Results on Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz:
 //!
 //! | Function | [datealgo](https://github.com/nakedible/datealgo-rs) | [hinnant](https://howardhinnant.github.io/date_algorithms.html) | [httpdate](https://github.com/pyfisch/httpdate) | [humantime](https://github.com/tailhook/humantime) | [time](https://github.com/time-rs/time) | [chrono](https://github.com/chronotope/chrono) |
 //! | ---------------------- | ------------- | --------- | --------- | --------- | --------- | --------- |
-//! | date_to_rd | **2.3 ns** | 4 ns | 3.2 ns | 3.2 ns | 17.7 ns | 7.2 ns |
-//! | rd_to_date | **3.6 ns** | 9.3 ns | 11.3 ns | 11.3 ns | 18.8 ns | 8.2 ns |
-//! | datetime_to_systemtime | **8.6 ns** | | 9.9 ns | 9.8 ns | 57.3 ns | 50.1 ns |
-//! | systemtime_to_datetime | **14.2 ns** | | 18.9 ns | 19 ns | 54.6 ns | 226.4 ns |
+//! | date_to_rd | **2.1 ns** | 3.3 ns | 3.3 ns | 3.6 ns | 15.1 ns | 6.5 ns |
+//! | rd_to_date | **3.2 ns** | 7.6 ns | 13.5 ns | 13.5 ns | 24.3 ns | 8 ns |
+//! | datetime_to_systemtime | **5.1 ns** | | 8.8 ns | 9 ns | 31.3 ns | 22.8 ns |
+//! | systemtime_to_datetime | **17.8 ns** | | 28.4 ns | 30.9 ns | 44.1 ns | 98.4 ns |
 //!
 //! Some code has been adapted from the libraries to produce comparable
 //! benchmarks.


### PR DESCRIPTION
Previous benchmarking method picked a random value and repeatedly tested the same value for each sample, leading to a case where performance differences due to different input values were marked as outliers.

Current method pregenerates a random array of values to be processed so each sample will contain a mix of input values, leading to them being averaged based on how often they appear in the randomized data.

This will cause an increase of 50 ps for overhead, which is not relevant for our benchmarking.