### PR TITLE
feat: Improve performance of date_to_weekday.

### DIFF
--- a/asm/date_to_weekday.asm
+++ b/asm/date_to_weekday.asm
@@ -14,19 +14,16 @@ datealgo::asm::date_to_weekday:
 	imul rcx, rdi, 1374389535
 	mov rdx, rcx
 	shr rdx, 37
-	imul edi, edi, 1461
+	lea edi, [rdi + 4*rdi]
 	shr edi, 2
 	shr rcx, 39
 	imul esi, esi, 979
-	add esi, -2919
+	add esi, -2855
 	shr esi, 5
 	sub eax, edx
 	add ecx, edi
 	add ecx, eax
-	lea eax, [rsi + rcx]
-	add eax, -306
-	movsxd rcx, eax
-	movabs rax, 2635249153387078802
-	imul rax, rcx
-	shr rax, 61
+	add ecx, esi
+	imul eax, ecx, 613566756
+	shr eax, 29
 	ret

--- a/asm/isoweeks_in_year.asm
+++ b/asm/isoweeks_in_year.asm
@@ -3,17 +3,15 @@ datealgo::asm::isoweeks_in_year:
 	imul rcx, rax, 1374389535
 	mov rdx, rcx
 	shr rdx, 37
-	imul eax, eax, 1461
+	lea eax, [rax + 4*rax]
 	shr eax, 2
 	shr rcx, 39
 	sub ecx, edx
-	add eax, ecx
-	inc eax
-	cdqe
-	movabs rcx, 2635249153387078802
-	imul rcx, rax
-	shr rcx, 61
-	cmp rcx, 3
+	add ecx, eax
+	imul ecx, ecx, 613566756
+	add ecx, 613566580
+	shr ecx, 29
+	cmp ecx, 3
 	je .LBB16_3
 	mov al, 52
 	cmp ecx, 4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ pub const fn rd_to_date(n: i32) -> (i32, u8, u8) {
 
 /// Convert a Gregorian date to its Computational calendar's counterpart.
 #[inline]
-const fn greg_to_comp(y: i32, m: u8, d: u8) -> (u32, u32, u32, u32) {
+const fn date_to_internal(y: i32, m: u8, d: u8) -> (u32, u32, u32, u32) {
     debug_assert!(y >= YEAR_MIN && y <= YEAR_MAX, "given year is out of range");
     debug_assert!(m >= consts::MONTH_MIN && m <= consts::MONTH_MAX, "given month is out of range");
     debug_assert!(d >= consts::DAY_MIN && d <= days_in_month(y, m), "given day is out of range");
@@ -398,7 +398,7 @@ const fn greg_to_comp(y: i32, m: u8, d: u8) -> (u32, u32, u32, u32) {
 /// > [10.1002/spe.3172](https://onlinelibrary.wiley.com/doi/full/10.1002/spe.3172).
 #[inline]
 pub const fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
-    let (c, y, m, d) = greg_to_comp(y, m, d);
+    let (c, y, m, d) = date_to_internal(y, m, d);
     let d = d - 1;
     // year
     let y = 1461 * y / 4 - c + c / 4;
@@ -518,7 +518,7 @@ pub const fn rd_to_weekday(n: i32) -> u8 {
 ///
 #[inline]
 pub const fn date_to_weekday((y, m, d): (i32, u8, u8)) -> u8 {
-    let (c, y, m, d) = greg_to_comp(y, m, d);
+    let (c, y, m, d) = date_to_internal(y, m, d);
     // year
     let y = 5 * y / 4 - c + c / 4;
     // month

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,25 @@ pub const fn rd_to_date(n: i32) -> (i32, u8, u8) {
     (y, m as u8, d as u8)
 }
 
+/// Convert a Gregorian date to its Computational calendar's counterpart.
+#[inline]
+const fn greg_to_comp(y: i32, m: u8, d: u8) -> (u32, u32, u32, u32) {
+    debug_assert!(y >= YEAR_MIN && y <= YEAR_MAX, "given year is out of range");
+    debug_assert!(m >= consts::MONTH_MIN && m <= consts::MONTH_MAX, "given month is out of range");
+    debug_assert!(d >= consts::DAY_MIN && d <= days_in_month(y, m), "given day is out of range");
+    let y = y.wrapping_add(YEAR_OFFSET) as u32;
+    let jf = (m < 3) as u32;
+    // year
+    let y = y - jf;
+    // century
+    let c = y / 100;
+    // month
+    let m = m as u32 + 12 * jf;
+    // day
+    let d = d as u32; // in Neri-Schneider's paper this is d - 1.
+    (c, y, m, d)
+}
+
 /// Convert Gregorian date to Rata Die
 ///
 /// Given a `(year, month, day)` tuple returns the days since Unix epoch
@@ -379,17 +398,8 @@ pub const fn rd_to_date(n: i32) -> (i32, u8, u8) {
 /// > [10.1002/spe.3172](https://onlinelibrary.wiley.com/doi/full/10.1002/spe.3172).
 #[inline]
 pub const fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
-    debug_assert!(y >= YEAR_MIN && y <= YEAR_MAX, "given year is out of range");
-    debug_assert!(m >= consts::MONTH_MIN && m <= consts::MONTH_MAX, "given month is out of range");
-    debug_assert!(d >= consts::DAY_MIN && d <= days_in_month(y, m), "given day is out of range");
-    let y = y.wrapping_add(YEAR_OFFSET) as u32;
-    // map
-    let jf = (m < 3) as u32;
-    let y = y - jf;
-    let m = m as u32 + 12 * jf;
-    let d = d as u32 - 1;
-    // century
-    let c = y / 100;
+    let (c, y, m, d) = greg_to_comp(y, m, d);
+    let d = d - 1;
     // year
     let y = 1461 * y / 4 - c + c / 4;
     // month
@@ -504,12 +514,19 @@ pub const fn rd_to_weekday(n: i32) -> u8 {
 ///
 /// # Algorithm
 ///
-/// Simply converts date to rata die and then rata die to weekday.
+/// Simple adaptation of `date_to_rd` to modulus 7 arithmetics.
 ///
 #[inline]
 pub const fn date_to_weekday((y, m, d): (i32, u8, u8)) -> u8 {
-    let rd = date_to_rd((y, m, d));
-    rd_to_weekday(rd)
+    let (c, y, m, d) = greg_to_comp(y, m, d);
+    // year
+    let y = 5 * y / 4 - c + c / 4;
+    // month
+    let m = (979 * m - 2855) / 32;
+    // result
+    let n = y + m + d;
+    const P32_OVER_SEVEN: u32 = ((1 << 31) / 7) << 1; // = (1 << 32) / 7
+    ((n.wrapping_mul(P32_OVER_SEVEN)) >> 29) as u8
 }
 
 /// Calculate next Gregorian date given a Gregorian date


### PR DESCRIPTION
In addition, factor out the mapping from Gregorian to Computational calendar into a private function, greg_to_comp, to avoid duplication.

My measurements report 13% improvement.

As usual, feel free to make changes on top of my PR or drop it altogether.

Happy holidays.
