### PR TITLE
chore: Add fasttime comparison benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ required-features = ["iai-bench"]
 chrono = "0.4.44"
 criterion = "0.8.2"
 fastrand = "2.3.0"
+fasttime = "0.2.3"
 iai-callgrind = "0.16.1"
 quickcheck = "1.1.0"
 time = { version = "0.3.47", features = ["quickcheck", "large-dates"] }

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -27,6 +27,9 @@ fn bench_rd_to_date(c: &mut Criterion) {
     group.bench_function("chrono", |b| {
         b.iter_custom(bencher(rand_rd, |rd| chrono::rd_to_date(black_box(rd))))
     });
+    group.bench_function("fasttime", |b| {
+        b.iter_custom(bencher(rand_rd, |rd| fasttime::rd_to_date(black_box(rd))))
+    });
     group.bench_function("time", |b| b.iter_custom(bencher(rand_rd, |rd| time::rd_to_date(black_box(rd)))));
     group.finish();
 }
@@ -50,6 +53,9 @@ fn bench_date_to_rd(c: &mut Criterion) {
     });
     group.bench_function("chrono", |b| {
         b.iter_custom(bencher(rand_date, |d| chrono::date_to_rd(black_box(d))))
+    });
+    group.bench_function("fasttime", |b| {
+        b.iter_custom(bencher(rand_date, |d| fasttime::date_to_rd(black_box(d))))
     });
     group.bench_function("time", |b| b.iter_custom(bencher(rand_date, |d| time::date_to_rd(black_box(d)))));
     group.finish();
@@ -83,6 +89,9 @@ fn bench_date_to_weekday(c: &mut Criterion) {
     group.bench_function("datealgo_alt2", |b| {
         b.iter_custom(bencher(rand_date, |d| datealgo_alt::date_to_weekday2(black_box(d))))
     });
+    group.bench_function("fasttime", |b| {
+        b.iter_custom(bencher(rand_date, |d| fasttime::date_to_weekday(black_box(d))))
+    });
     group.finish();
 }
 
@@ -96,6 +105,9 @@ fn bench_next_date(c: &mut Criterion) {
     });
     group.bench_function("chrono", |b| {
         b.iter_custom(bencher(chrono::rand_date, |d| chrono::next_date(black_box(d))))
+    });
+    group.bench_function("fasttime", |b| {
+        b.iter_custom(bencher(fasttime::rand_date, |d| fasttime::next_date(black_box(d))))
     });
     group.bench_function("time", |b| {
         b.iter_custom(bencher(time::rand_date, |d| time::next_date(black_box(d))))
@@ -113,6 +125,9 @@ fn bench_prev_date(c: &mut Criterion) {
     });
     group.bench_function("chrono", |b| {
         b.iter_custom(bencher(chrono::rand_date, |d| chrono::prev_date(black_box(d))))
+    });
+    group.bench_function("fasttime", |b| {
+        b.iter_custom(bencher(fasttime::rand_date, |d| fasttime::prev_date(black_box(d))))
     });
     group.bench_function("time", |b| {
         b.iter_custom(bencher(time::rand_date, |d| time::prev_date(black_box(d))))

--- a/benches/compare_support.rs
+++ b/benches/compare_support.rs
@@ -703,6 +703,42 @@ mod chrono {
     }
 }
 
+mod fasttime {
+    pub fn rand_date() -> fasttime::Date {
+        let (y, m, d) = super::rand_date();
+        fasttime::Date::from_ymd(y, m, d).unwrap()
+    }
+
+    #[inline]
+    pub fn next_date(d: fasttime::Date) -> fasttime::Date {
+        d.add_days(1).unwrap()
+    }
+
+    #[inline]
+    pub fn prev_date(d: fasttime::Date) -> fasttime::Date {
+        d.add_days(-1).unwrap()
+    }
+
+    #[inline]
+    pub fn rd_to_date(n: i32) -> (i32, u8, u8) {
+        let date = fasttime::Date::from_days_since_unix_epoch(n as i64).unwrap();
+        (date.year, date.month, date.day)
+    }
+
+    #[inline]
+    pub fn date_to_rd((y, m, d): (i32, u8, u8)) -> i32 {
+        fasttime::Date::from_ymd(y, m, d).unwrap().days_since_unix_epoch() as i32
+    }
+
+    #[inline]
+    pub fn date_to_weekday((y, m, d): (i32, u8, u8)) -> u8 {
+        fasttime::Date::from_ymd(y, m, d)
+            .unwrap()
+            .weekday()
+            .number_from_monday()
+    }
+}
+
 mod time {
     use std::time::SystemTime;
 

--- a/benches/compare_zen.rs
+++ b/benches/compare_zen.rs
@@ -48,6 +48,7 @@ fn bench_rd_to_date(suite: &mut Suite) {
         bench_from_inputs(group, "httpdate", Arc::clone(&inputs), httpdate::rd_to_date);
         bench_from_inputs(group, "humantime", Arc::clone(&inputs), humantime::rd_to_date);
         bench_from_inputs(group, "chrono", Arc::clone(&inputs), chrono::rd_to_date);
+        bench_from_inputs(group, "fasttime", Arc::clone(&inputs), fasttime::rd_to_date);
         bench_from_inputs(group, "time", inputs, time::rd_to_date);
     });
 }
@@ -63,6 +64,7 @@ fn bench_date_to_rd(suite: &mut Suite) {
         bench_from_inputs(group, "httpdate", Arc::clone(&inputs), httpdate::date_to_rd);
         bench_from_inputs(group, "humantime", Arc::clone(&inputs), humantime::date_to_rd);
         bench_from_inputs(group, "chrono", Arc::clone(&inputs), chrono::date_to_rd);
+        bench_from_inputs(group, "fasttime", Arc::clone(&inputs), fasttime::date_to_rd);
         bench_from_inputs(group, "time", inputs, time::date_to_rd);
     });
 }
@@ -77,6 +79,9 @@ fn bench_next_date(suite: &mut Suite) {
 
         let chrono_inputs = seeded_inputs(chrono::rand_date);
         bench_from_inputs(group, "chrono", chrono_inputs, chrono::next_date);
+
+        let fasttime_inputs = seeded_inputs(fasttime::rand_date);
+        bench_from_inputs(group, "fasttime", fasttime_inputs, fasttime::next_date);
 
         let time_inputs = seeded_inputs(time::rand_date);
         bench_from_inputs(group, "time", time_inputs, time::next_date);
@@ -93,6 +98,9 @@ fn bench_prev_date(suite: &mut Suite) {
 
         let chrono_inputs = seeded_inputs(chrono::rand_date);
         bench_from_inputs(group, "chrono", chrono_inputs, chrono::prev_date);
+
+        let fasttime_inputs = seeded_inputs(fasttime::rand_date);
+        bench_from_inputs(group, "fasttime", fasttime_inputs, fasttime::prev_date);
 
         let time_inputs = seeded_inputs(time::rand_date);
         bench_from_inputs(group, "time", time_inputs, time::prev_date);


### PR DESCRIPTION
## What changed

- add `fasttime` as a dev-dependency for benchmarking
- wire `fasttime` into the existing compare benchmark support wrappers
- add `fasttime` entries to the Zenbench and Criterion compare suites where the crate exposes a fair matching operation

## Why

`fasttime` is another Rust implementation of Ben Joffe's date conversion work. Adding it to the compare suite makes it easy to evaluate against `datealgo`, `time`, and `chrono` using the existing benchmark harnesses.

The integrated operations are:

- `rd_to_date`
- `date_to_rd`
- `next_date`
- `prev_date`
- Criterion-only `date_to_weekday`

## Validation

- `cargo fmt --all`
- `cargo check --benches`
- `cargo bench --bench compare -- --group=compare_rd_to_date`
- `cargo bench --bench compare -- --group=compare_date_to_rd`
- `cargo bench --bench compare -- --group=compare_next_date`
- `cargo bench --bench compare -- --group=compare_prev_date`
