### PR TITLE
ci: Harden basic benchmark PR reporting

### DIFF
--- a/.github/workflows/basic-bench.yml
+++ b/.github/workflows/basic-bench.yml
@@ -30,7 +30,12 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set +e
-          python3 scripts/verify_basic_bench.py --git-ref "$BASE_SHA" > basic-bench-report.txt
+          # CI gets a heavier confirmation pass than local use so that a
+          # reported change is backed by a more stable median on noisy runners.
+          python3 scripts/verify_basic_bench.py \
+            --git-ref "$BASE_SHA" \
+            --confirm-runs 9 \
+            > basic-bench-report.txt
           status=$?
           set -e
 

--- a/.github/workflows/basic-bench.yml
+++ b/.github/workflows/basic-bench.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/github-script@v7
         env:
           VERIFY_STATUS: ${{ steps.verify.outputs.status }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
             const fs = require("fs");
@@ -59,6 +61,8 @@ jobs:
             const marker = "<!-- verify-basic-bench -->";
             const report = fs.readFileSync("basic-bench-report.txt", "utf8").trimEnd();
             const status = process.env.VERIFY_STATUS;
+            const baseSha = process.env.BASE_SHA;
+            const headSha = process.env.HEAD_SHA;
             const headline = status === "0"
               ? "No meaningful `basic` benchmark changes detected."
               : "Meaningful `basic` benchmark changes detected.";
@@ -69,7 +73,8 @@ jobs:
               "",
               headline,
               "",
-              "Compared this pull request head against its base commit with `./scripts/verify_basic_bench.py`.",
+              "Compared this pull request branch head against its base commit with `./scripts/verify_basic_bench.py`.",
+              `Compared commits: ${baseSha} -> ${headSha}`,
               "",
               "```text",
               report,


### PR DESCRIPTION
## What changed

- increase the CI benchmark verifier confirmation pass from 3 runs per side to 9 runs per side
- include the compared base and head commit hashes in the sticky PR benchmark comment
- keep the local verifier defaults unchanged

## Why

A noisy-runner false positive showed that the GitHub Actions reporting path was still too eager to confirm some changes. This makes the PR benchmark comment more conservative before it reports a confirmed `basic` benchmark difference, while also making it explicit which two commits were compared.

The verifier protocol and threshold stay the same. This change only hardens the CI reporting path.

## Validation

- `python3 -m py_compile scripts/verify_basic_bench.py`
- `python3 scripts/verify_basic_bench.py --git-ref HEAD --groups rd_to_date --confirm-runs 9`
